### PR TITLE
Add DB Upload functionality to postgresql (#64)

### DIFF
--- a/telemetry/db_upload.py
+++ b/telemetry/db_upload.py
@@ -14,24 +14,26 @@ class DBUpload:
                     id SERIAL PRIMARY KEY,
                     timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     message_name VARCHAR(50),
-                    value INTEGER 
+                    value FLOAT 
                 );
             """)
             self.connection.commit()
         except Exception as e:
             print(f"Error creating table: {e}")
 
+    def insert_data_point(self, key, value):
+        self.cursor.execute("""
+            INSERT INTO telemetry (message_name, value)
+            VALUES (%s, %s)
+        """, (key, float(value)))
+
     def upload(self, buffer):
         try:
             for data in buffer:
                 for key, value in data.items():
-                    self.cursor.execute("""
-                        INSERT INTO telemetry (message_name, value)
-                        VALUES (%s, %s)
-                    """, (key, int(value)))
+                    self.insert_data_point(key, value)
             self.connection.commit()
             print("Data uploaded successfully")
-            time.sleep(1)
         except Exception as e:
             print(f"Error uploading data: {e}")
             self.connection.rollback()

--- a/telemetry/db_upload.py
+++ b/telemetry/db_upload.py
@@ -1,28 +1,40 @@
-from influxdb_client import InfluxDBClient, Point
-from influxdb_client.client.write_api import SYNCHRONOUS
 import time
-import random
-
-# Configuration
-url = "http://localhost:8086"
-token = "token"
-org = "org"
-bucket = "bucket"
-
-client = InfluxDBClient(url=url, token=token, org=org)
-write_api = client.write_api(write_options=SYNCHRONOUS)
+from db.connect import connect_to_db
 
 class DBUpload:
+    def __init__(self):
+        self.connection = connect_to_db()
+        self.cursor = self.connection.cursor()
+        self.init_table()
+
+    def init_table(self):
+        try:
+            self.cursor.execute("""
+                CREATE TABLE IF NOT EXISTS telemetry (
+                    id SERIAL PRIMARY KEY,
+                    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    message_name VARCHAR(50),
+                    value INTEGER 
+                );
+            """)
+            self.connection.commit()
+        except Exception as e:
+            print(f"Error creating table: {e}")
+
     def upload(self, buffer):
-        point = Point("telemetry")
-        for data in buffer:
-            for key, value in data.items():
-                point = point.field(key, value)
-        write_api.write(bucket=bucket, org=org, record=point)
-        print(data)
-        time.sleep(1)
-
-
+        try:
+            for data in buffer:
+                for key, value in data.items():
+                    self.cursor.execute("""
+                        INSERT INTO telemetry (message_name, value)
+                        VALUES (%s, %s)
+                    """, (key, int(value)))
+            self.connection.commit()
+            print("Data uploaded successfully")
+            time.sleep(1)
+        except Exception as e:
+            print(f"Error uploading data: {e}")
+            self.connection.rollback()
 
 '''
 assume every 200ms


### PR DESCRIPTION
- added initializer for the DBUpload class and leveraged existing db connect stuff from simulation
  - this means that now db connection info for telemetry must be stored in a .env with variables DB_NAME, DB_USER, DB_PASSWORD, DB_HOST
- added method for initializing the table if it doesn't exist and migrated the existing upload method to postgres
- tested with simple script to ensure proper initialization and insertion into my local db telemetry table